### PR TITLE
Update link to Getting Started with Cloud Office

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ title: Rackspace Support Network
 					<div class="four columns">
 						<ul class="unstyled">
 							<li><a class="cloud_sites" href="http://www.rackspace.com/knowledge_center/getting-started/cloud-sites">Get Started with Cloud Sites<span class="caret">&raquo;</span></a></li>
-							<li><a class="cloud_office" href="http://www.rackspace.com/knowledge_center/?dis=ea">Get Started with Cloud Office<span class="caret">&raquo;</span></a></li>					
+							<li><a class="cloud_office" href="https://support.rackspace.com/how-to/cloud-office-control-panel/">Get Started with Cloud Office<span class="caret">&raquo;</span></a></li>					
 							<li><a class="cloud_cp" target="_blank" href="https://mycloud.rackspace.com">Go to the Cloud Control Panel<span class="caret">&raquo;</span></a></li>
 						</ul>
 					</div>


### PR DESCRIPTION
Trent noticed that this link went to the How-To landing page. Updated to point to Cloud Office Control Panel article. 