### PR TITLE
Change link target to How-To > Cloud Office tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ title: Rackspace Support Network
 					<div class="four columns">
 						<ul class="unstyled">
 							<li><a class="cloud_sites" href="http://www.rackspace.com/knowledge_center/getting-started/cloud-sites">Get Started with Cloud Sites<span class="caret">&raquo;</span></a></li>
-							<li><a class="cloud_office" href="https://support.rackspace.com/how-to/cloud-office-control-panel/">Get Started with Cloud Office<span class="caret">&raquo;</span></a></li>					
+							<li><a class="cloud_office" href="https://support.rackspace.com/how-to/?dis=ea#cloud-office/">Get Started with Cloud Office<span class="caret">&raquo;</span></a></li>					
 							<li><a class="cloud_cp" target="_blank" href="https://mycloud.rackspace.com">Go to the Cloud Control Panel<span class="caret">&raquo;</span></a></li>
 						</ul>
 					</div>


### PR DESCRIPTION
Changing link to point to correct location.  Cloud Office Control panel article not correct getting started place for all Cloud Office offerings. 