### PR TITLE
Updates to support landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,14 +63,13 @@ title: Rackspace Support Network
             <h3>MANAGE YOUR ACCOUNT</h3>
             <ul class="unstyled">
               <li><a href="https://support.rackspace.com/how-to/billing-services-overview/">Billing Services Overview</a></li>
-              <li><a href="http://www.rackspace.com/knowledge_center/article/view-and-reset-your-api-key">View or Reset Your API Key</a></li>
-              <li><a href="http://www.rackspace.com/knowledge_center/article/managing-role-based-access-control-rbac">Adding Users To Your Account</a></li>
-              <li><a href="http://www.rackspace.com/knowledge_center/article/rackspace-cloud-billing-faq">Cloud Billing FAQ</a></li>
+              <li><a href="https://support.rackspace.com/how-to/view-and-reset-your-api-key/">View or Reset Your API Key</a></li>
+              <li><a href="https://support.rackspace.com/how-to/managing-role-based-access-control-rbac/">Adding Users To Your Account</a></li>
+              <li><a href="https://support.rackspace.com/how-to/rackspace-billing-faq/">Cloud Billing FAQ</a></li>
             </ul>
           </div>
           <div class="four columns">
             <ul class="unstyled">
-              <li><a class="cloud_sites" href="http://www.rackspace.com/knowledge_center/getting-started/cloud-sites">Get Started with Cloud Sites<span class="caret">&raquo;</span></a></li>
               <li><a class="cloud_office" href="https://support.rackspace.com/how-to/?dis=ea#cloud-office/">Get Started with Cloud Office<span class="caret">&raquo;</span></a></li>
               <li><a class="cloud_cp" target="_blank" href="https://mycloud.rackspace.com">Go to the Cloud Control Panel<span class="caret">&raquo;</span></a></li>
             </ul>
@@ -84,21 +83,21 @@ title: Rackspace Support Network
           <div class="six columns">
             <h2 class="section-heading">Keys to Success In The Cloud</h2>
             <dl class="step">
-              <dt><a href="http://www.rackspace.com/knowledge_center/article/rackspace-cloud-essentials-creating-a-cloud-server">Build a cloud server<span class="caret">&raquo;</span></a></dt>
+              <dt><a href="https://support.rackspace.com/how-to/create-a-cloud-server/">Build a cloud server<span class="caret">&raquo;</span></a></dt>
               <dd>Build a cloud server with just a few clicks in the cloud control panel.</dd>
 
-              <dt><a href="http://www.rackspace.com/knowledge_center/article/configuring-basic-security-0">Secure your server<span class="caret">&raquo;</span></a></dt>
+              <dt><a href="https://support.rackspace.com/how-to/configuring-basic-security/">Secure your server<span class="caret">&raquo;</span></a></dt>
               <dd>Basic firewall rules will secure your server to ensure your information is safe.</dd>
 
-              <dt><a href="http://www.rackspace.com/knowledge_center/article/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image">Create an image of your server<span class="caret">&raquo;</span></a></dt>
+              <dt><a href="https://support.rackspace.com/how-to/create-an-image-of-a-server-and-restore-a-server-from-a-saved-image/">Create an image of your server<span class="caret">&raquo;</span></a></dt>
               <dd>Images help you to scale or restore your server to its original state.</dd>
 
               <dt>Configure Cloud Backup</dt>
               <dd>File-level backup with space-saving de-duplication.<br />
-              <a class="backup_link" href="http://www.rackspace.com/knowledge_center/article/rackspace-cloud-backup-install-the-agent-windows">For Windows servers<span class="caret">&raquo;</span></a>
-              <a class="backup_link" href="http://www.rackspace.com/knowledge_center/article/rackspace-cloud-backup-install-the-agent-on-linux">For Linux servers<span class="caret">&raquo;</span></a></dd>
+              <a class="backup_link" href="https://support.rackspace.com/how-to/rackspace-cloud-backup-install-the-agent-on-windows/">For Windows servers<span class="caret">&raquo;</span></a>
+              <a class="backup_link" href="https://support.rackspace.com/how-to/rackspace-cloud-backup-install-the-agent-on-linux/">For Linux servers<span class="caret">&raquo;</span></a></dd>
 
-              <dt><a href="http://www.rackspace.com/knowledge_center/frequently-asked-question/how-do-i-use-cloud-files-and-cdn">Upload content to Cloud Files<span class="caret">&raquo;</span></a></dt>
+              <dt><a href="https://support.rackspace.com/how-to/getting-started-with-cloud-files-and-cdn/">Upload content to Cloud Files<span class="caret">&raquo;</span></a></dt>
               <dd>Cloud Files and the CDN can store and serve your media files independent of your server.</dd>
             </dl>
           </div>
@@ -106,7 +105,7 @@ title: Rackspace Support Network
             <div class="row wordpress_section">
               <h2 class="section-heading">WordPress</h2>
               <p>Get the popular CMS and blogging software with a few clicks and Cloud Orchestration.</p>
-              <a href="http://www.rackspace.com/knowledge_center/article/deploy-wordpress-packages-by-using-rackspace-cloud-orchestration">Start Building Now<span class="caret">&raquo;</span></a>
+              <a href="https://support.rackspace.com/how-to/deploy-wordpress-packages-by-using-rackspace-cloud-orchestration/">Start Building Now<span class="caret">&raquo;</span></a>
             </div>
           </div>
         </div>
@@ -122,51 +121,48 @@ title: Rackspace Support Network
                 <a href="https://support.rackspace.com/how-to/cloud-servers/" class="card support-servers">
                   <h4><span>Cloud</span> Servers</h4>
                 </a>
-                <a href="http://www.rackspace.com/knowledge_center/getting-started/cloud-files" class="card support-files">
+                <a href="https://support.rackspace.com/how-to/cloud-files/" class="card support-files">
                   <h4><span>Cloud</span> Files</h4>
                 </a>
-                <a href="http://www.rackspace.com/knowledge_center/getting-started/cloud-sites" class="card support-sites">
-                  <h4><span>Cloud</span> Sites</h4>
-                </a>
-                <a href="http://www.rackspace.com/knowledge_center/getting-started/cloud-load-balancers" class="card support-load-balancers">
+                <a href="https://support.rackspace.com/how-to/cloud-load-balancers/" class="card support-load-balancers">
                   <h4 class="x-small"><span>Cloud</span> Load Balancers</h4>
                 </a>
-                <a href="http://www.rackspace.com/knowledge_center/getting-started/cloud-databases" class="card support-databases">
+                <a href="https://support.rackspace.com/how-to/cloud-databases/" class="card support-databases">
                   <h4><span>Cloud</span> Databases</h4>
+                </a>
+                <a href="https://support.rackspace.com/how-to/rackspace-monitoring/" class="card support-monitoring">
+                  <h4 class="small"><span>Cloud</span> Monitoring</h4>
                 </a>
               </div>
               <div class="slide">
-                <a href="http://www.rackspace.com/knowledge_center/getting-started/cloud-monitoring" class="card support-monitoring">
-                  <h4 class="small"><span>Cloud</span> Monitoring</h4>
-                </a>
-                <a href="http://www.rackspace.com/knowledge_center/getting-started/cloud-backup" class="card support-backup">
+                <a href="https://support.rackspace.com/how-to/cloud-backup/" class="card support-backup">
                   <h4><span>Cloud</span> Backup</h4>
                 </a>
                 <!-- no link  -->
-                <a href="http://docs.rackspace.com/images/api/v2/ci-gettingstarted/content/ch_image_preface.html" class="card support-images">
+                <a href="https://support.rackspace.com/how-to/cloud-images/" class="card support-images">
                   <h4><span>Cloud</span> Images</h4>
                 </a>
-                <a href="http://www.rackspace.com/knowledge_center/getting-started/cloud-block-storage" class="card support-block-storage">
+                <a href="https://support.rackspace.com/how-to/cloud-block-storage/" class="card support-block-storage">
                   <h4 class="x-small"><span>Cloud</span> Block Storage</h4>
                 </a>
                 <a href=" https://support.rackspace.com/how-to/rpc-openstack/" class="card support-private-cloud">
                   <h4 class="x-small"><span>Rackspace</span> Private Cloud</h4>
                 </a>
-              </div>
-              <div class="slide">
-                <a href="http://www.rackspace.com/knowledge_center/getting-started/rackconnect" class="card support-rackconnect">
+                <a href="https://support.rackspace.com/how-to/rackconnect/" class="card support-rackconnect">
                   <h4 class="x-small"><span>Rackspace</span> RackConnect</h4>
                 </a>
-                <a href="http://www.rackspace.com/knowledge_center/article/getting-started-with-cloud-networks" class="card support-networks">
+              </div>
+              <div class="slide">
+                <a href="https://support.rackspace.com/how-to/cloud-networks/" class="card support-networks">
                   <h4><span>Cloud</span> Networks</h4>
                 </a>
                 <a href="https://support.rackspace.com/how-to/cloud-dns/" class="card support-dns">
                   <h4><span>Cloud</span> DNS</h4>
                 </a>
-                <a href="http://www.rackspace.com/knowledge_center/getting-started/rackspace-email" class="card support-email">
+                <a href="https://support.rackspace.com/how-to/rackspace-email/" class="card support-email">
                   <h4><span>Rackspace</span> Email</h4>
                 </a>
-                <a href="http://www.rackspace.com/knowledge_center/getting-started/exchange" class="card support-exchange">
+                <a href="https://support.rackspace.com/how-to/exchange/" class="card support-exchange">
                   <h4><span>Rackspace</span> Hosted Exchange</h4>
                 </a>
               </div>


### PR DESCRIPTION
Partially closes H2 issue #1524 including these:

Remove “Get Started with Cloud Sites”

Fix link on top navigation bar: API Documentation needs to go to Developer doc (https://developer.rackspace.com/docs/)

In Getting Started Using the Rackspace Managed Cloud, need to remove “Get Started with Cloud Sites”.

“Secure your server” points to a KC article. Needs to point to How-To.

“Create an image of your server” points to a KC article. Needs to point to How-To.

“Configure Cloud Backup” points to KC articles. Needs to point to How-To.

“Upload content to Cloud Files” points to a KC article. Needs to point to How-To.

Word Press points to a KC article. Needs to point to How-To.

The product icons in the carousel point to KC. Need to point to How-To.

Cloud servers image icon missing in product carousel