### PR TITLE
RSWEB-7678 [data] - Assist support.rackspace.com team with GA/GTM implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,22 +14,30 @@ title: Rackspace Support Network
     <!-- third-party includes -->
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,900' rel='stylesheet'1 type='text/css'>
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="{% asset_path normalize.css %}">
-        <link rel="stylesheet" href="{% asset_path skeleton.css %}">
+    <link rel="stylesheet" href="{% asset_path normalize.css %}">
+    <link rel="stylesheet" href="{% asset_path skeleton.css %}">
 
-        <link rel="stylesheet"href="{% asset_path carousel.css %}"/>
+    <link rel="stylesheet"href="{% asset_path carousel.css %}"/>
 
-        <link
-        rel="stylesheet"href="https://4c5f0f4824b5f0326df3-ba48d26ab4f3c4858b16738b454bedcc.ssl.cf1.rackcdn.com/includes/css/style2.css"/>
+    <link rel="stylesheet"href="https://4c5f0f4824b5f0326df3-ba48d26ab4f3c4858b16738b454bedcc.ssl.cf1.rackcdn.com/includes/css/style2.css"/>
 
+    <link rel="stylesheet"href="{% asset_path rax-footer.css %}"/>
 
-        <link rel="stylesheet"href="{% asset_path rax-footer.css %}"/>
-
+    <!-- Google Tag Manager -->
+    <script>
+    dataLayer = [];
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-MW68KW');
+    </script>
+    <!-- End Google Tag Manager -->
 
     <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
 
-        <script src="{% asset_path carousel.min.js %}"></script>
+    <script src="{% asset_path carousel.min.js %}"></script>
 
     <script type="text/javascript" src="https://c4d62906a15616653758-49dececd4e3f03377b7f33fac7abfae8.ssl.cf5.rackcdn.com/prod/raxheaderservice.js"></script>
     <script type="text/javascript">
@@ -38,6 +46,10 @@ title: Rackspace Support Network
 
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MW68KW"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript>
       <a href="https://support.rackspace.com/how-to/">How-To</a>
       <a href="https://developer.rackspace.com/docs/">API Documentation</a>
@@ -175,16 +187,6 @@ title: Rackspace Support Network
       </div>
     </div>
     </div>
-        <div id="raxheaderfooterservice-footercontent"></div>
-      <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-81189538-1', 'auto');
-      ga('send', 'pageview');
-
-      </script>
+    <div id="raxheaderfooterservice-footercontent"></div>
   </body>
 </html>


### PR DESCRIPTION
This PR replaces the Google Analytics `script` snippet with updated Google Tag Manager snippets.

The GTM container is configured to report to both the Support and Global eCommerce GA properties:

UA-35639070-1
UA-81189538-1

The same work has been done for the other support.rackspace.com content per Nexus content templates:

See https://github.com/rackerlabs/nexus-control/pull/613